### PR TITLE
Unpin `conda-build` on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ install:
    - conda install python=$PYTHON_VERSION
    # Install basic conda dependencies.
    - touch $HOME/miniconda/conda-meta/pinned
-   - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
    - conda install conda-build
    - conda install jinja2
    # Return to the git repo.


### PR DESCRIPTION
The bug that was bothering us in `conda-build` has subsequently been fixed and newer versions exist without it. Thus, we unpin it.