### PR TITLE
Fix CentOS linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,5 +115,6 @@ add_dependencies(rank_filter check)
 add_test(NAME nosetest COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test/run_nosetest.py ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} ${CMAKE_SOURCE_DIR})
 
 # Install the module in the Python site-packages folder.
+install(CODE "execute_process(COMMAND patchelf --remove-needed vigranumpycore.so ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/rank_filter.so)")
 install(TARGETS rank_filter DESTINATION ${PYTHON_SITE_PACKAGES})
 #install(FILES include/rank_filter.hxx DESTINATION ${VIGRA_INCLUDE_DIR})

--- a/rank_filter.recipe/build.sh
+++ b/rank_filter.recipe/build.sh
@@ -65,7 +65,3 @@ eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make -j${CPU_COUNT}
 
 # "install" to the build prefix (conda will relocate these files afterwards)
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make install
-
-if [[ `uname` == 'Linux' ]]; then
-    patchelf --remove-needed vigranumpycore.so $PREFIX/lib/python2.7/site-packages/rank_filter.so
-fi

--- a/rank_filter.recipe/build.sh
+++ b/rank_filter.recipe/build.sh
@@ -65,3 +65,7 @@ eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make -j${CPU_COUNT}
 
 # "install" to the build prefix (conda will relocate these files afterwards)
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make install
+
+if [[ `uname` == 'Linux' ]]; then
+    patchelf --remove-needed vigranumpycore.so $PREFIX/lib/python2.7/site-packages/rank_filter.so
+fi

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -146,6 +146,7 @@ requirements:
   # listed explicitly if they are required.
   build:
     - cmake
+    - patchelf >=0.8    # [linux]
     - boost
     - python
     - nose


### PR DESCRIPTION
On some versions of Linux, `rank_filter.so` gets an added linkage to `vigranumpycore.so`. However, it doesn't included the path with it. This linkage is not actually needed and turns out to cause problems when trying to import `rank_filter`. So, this adds a step to simply remove this linkage from the library on Linux. It has no effect if the linkage is not there.