### PR TITLE
Clean everything after recipe build

### DIFF
--- a/rank_filter.recipe/build.sh
+++ b/rank_filter.recipe/build.sh
@@ -65,3 +65,6 @@ eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make -j${CPU_COUNT}
 
 # "install" to the build prefix (conda will relocate these files afterwards)
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make install
+
+# Clean up any loose ends including CMake files.
+make reset


### PR DESCRIPTION
Sometimes the build processes latches on to things in the source directory this should help that.