### PR TITLE
Ensure Cython is installed before setup when using pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup_requires = cython_dep + numpy_dep
 setup_requires = [] if sys.argv[1] == "bdist_conda" else setup_requires
 build_requires = cython_dep + numpy_dep + boost_dep
 install_requires = numpy_dep + boost_dep
+install_requires += [] if sys.argv[1] == "bdist_conda" else cython_dep
 tests_require = cython_dep + numpy_dep
 
 include_dirs = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("src/version.pxi", "w") as f:
          "__version__ = " + "\"" + str(version) + "\""
      ])
 
-cython_dep = ["Cython >= 0.23"]
+cython_dep = ["cython >= 0.23"]
 numpy_dep = ["numpy >= 1.7"]
 boost_dep = ["boost >= 1.56"]
 boost_dep = (boost_dep if sys.argv[1] == "bdist_conda" else [])

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ boost_dep = (boost_dep if sys.argv[1] == "bdist_conda" else [])
 
 setup_requires = cython_dep + numpy_dep
 setup_requires = [] if sys.argv[1] == "bdist_conda" else setup_requires
-build_requires = setup_requires + boost_dep
+build_requires = cython_dep + numpy_dep + boost_dep
 install_requires = numpy_dep + boost_dep
 tests_require = cython_dep + numpy_dep
 


### PR DESCRIPTION
Makes sure Cython gets picked up as a setup requirement so it is installed before building. This is trying to workaround an issue with `pip`. Related SO question ( http://stackoverflow.com/questions/9959279/detect-pip-in-setup-py ).