### PR TITLE
Cleanup python pack hack

### DIFF
--- a/run_unittest.py
+++ b/run_unittest.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 
-import os
 import subprocess
 import sys
 

--- a/run_unittest.py
+++ b/run_unittest.py
@@ -9,7 +9,7 @@ import sys
 def main(*argv):
     argv = list(argv)
 
-    os.environ["PYTHONPATH"] = argv[1] + ":" + os.environ.get("PYTHONPATH", "")
+    sys.path.insert(0, argv[1])
 
     return(subprocess.check_call([sys.executable, "-m", "unittest"] + argv[2:],
                                  stdin=sys.stdin,


### PR DESCRIPTION
Switches to using `sys.path`, which is a little better. Still a hack though.