### PR TITLE
Select Cython/VIGRA bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c++
 compiler: gcc
 env:
+   - PYTHON_VERSION="2.7" HAS_VIGRA="true" USE_CYTHON="false"
    - PYTHON_VERSION="2.7" HAS_VIGRA="true"
    - PYTHON_VERSION="2.7" HAS_VIGRA="false"
    - PYTHON_VERSION="3.5" HAS_VIGRA="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: c++
 compiler: gcc
 env:
-   - PYTHON_VERSION="2.7" HAS_VIGRA="true" USE_CYTHON="false"
-   - PYTHON_VERSION="2.7" HAS_VIGRA="true"
-   - PYTHON_VERSION="2.7" HAS_VIGRA="false"
-   - PYTHON_VERSION="3.5" HAS_VIGRA="false"
+   - PYTHON_VERSION="2.7" USE_CYTHON="false"
+   - PYTHON_VERSION="2.7"
+   - PYTHON_VERSION="3.5"
 before_install:
    # Move out of git directory to build root.
    - git fetch --unshallow --tags
@@ -40,7 +39,6 @@ install:
    # Create the test environment and install dependencies.
    - conda create --use-local -n testenv python=$PYTHON_VERSION
    - source activate testenv
-   - "[[ ${HAS_VIGRA} == true ]] && conda install vigra || true"
    # Clean up downloads as there are quite a few and they waste space/memory.
    - conda clean -tipsy
    - rm -rfv $HOME/.cache/pip

--- a/rank_filter.recipe/build.sh
+++ b/rank_filter.recipe/build.sh
@@ -18,6 +18,10 @@ else
     DEFAULT_CXX_LDFLAGS=""
 fi
 
+if [ -z "${USE_CYTHON}" ] || [ "${USE_CYTHON}" == "<UNDEFINED>" ];
+then
+    unset USE_CYTHON
+fi
 if [ -z "${CC}" ] || [ "${CC}" == "<UNDEFINED>" ];
 then
     CC=$DEFAULT_CC

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -150,8 +150,8 @@ requirements:
     - patchelf >=0.8    # [linux]
     - boost
     - python
-    - cython
     - numpy
+    {{ "- cython" if environ.get('USE_CYTHON', "true") == "true" else "- vigra" }}
     
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
@@ -159,6 +159,7 @@ requirements:
     - boost
     - python
     - numpy
+    {{ "" if environ.get('USE_CYTHON', "true") == "true" else "- vigra" }}
 
 test:
   ## files which are copied from the recipe into the (temporary) test

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -64,7 +64,7 @@ build:
 
   # The build number should be incremented for new builds of the same version
   #number: 1       # (defaults to 0)
-  string: py{{py}}np{{np}}{{ "" if environ.get('USE_CYTHON', "true") == "true" else "_vg" }}
+  string: py{{py}}np{{np if np else ""}}{{ "" if environ.get('USE_CYTHON', "true") == "true" else "_vg" }}
 
   ## Optional Python entry points
   #entry_points:

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -60,6 +60,7 @@ build:
     - CXX
     - CXX_FLAGS
     - CXX_LDFLAGS
+    - USE_CYTHON
 
   # The build number should be incremented for new builds of the same version
   #number: 1       # (defaults to 0)

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -64,9 +64,7 @@ build:
 
   # The build number should be incremented for new builds of the same version
   #number: 1       # (defaults to 0)
-  #string: abc     # (defaults to default conda build string plus the build
-  #                # number)
-  #                # The build string cannot contain a dash '-' character
+  string: py{{py}}np{{np}}{{ "" if environ.get('USE_CYTHON', "true") == "true" else "_vg" }}
 
   ## Optional Python entry points
   #entry_points:


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/rank_filter/issues/27

Provides option to build with Cython or VIGRA as desired. If `USE_CYTHON` is set to `false`, the bindings will be built with VIGRA. If it is set to `true` or not set, the Cython bindings will be built. In the event that VIGRA bindings are built, the conda package will have a `_vg` suffix added to the build string.

This mainly exists to provide support for the legacy bindings if issues are found with the new bindings. In reality, the VIGRA bindings are deprecated and are on there way out. However, they may come in hand if bugs are found in the Cython bindings.

Includes a test on Travis CI to show this is working.