### PR TITLE
Require version 18.0 of `setuptools` or higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,17 @@ import os
 import sys
 from glob import glob
 from distutils.sysconfig import get_config_var, get_python_inc
+from distutils.version import LooseVersion
+
+import setuptools
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext as _build_ext
 
 import versioneer
 
+
+assert LooseVersion(setuptools.__version__) >= LooseVersion("18.0"), \
+        "Requires `setuptools` version 18.0 or higher."
 
 class build_ext(_build_ext):
     def finalize_options(self):


### PR DESCRIPTION
Require `setuptools` version 18.0 or higher as it has support for automatically building with Cython. ( https://bitbucket.org/pypa/setuptools/commits/424966904023 ) We require this to build our bindings. See related SO comment ( http://stackoverflow.com/a/30762543 ).