### PR TITLE
Fix benchmarking to run on the correct version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
    - conda build rank_filter.recipe
    - mv .git/shallow-not .git/shallow || true
    # Run the benchmarks.
-   - conda install --use-local -n testenv rank_filter
+   - conda install --use-local -n testenv rank_filter==$VERSION
    - src/benchmark_rank_filter.py
 # Use container format for TravisCI.
 #sudo: false  # Currently not possible as we need a newer copy of `gcc` that has C++11 features.

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ install:
    - conda install jinja2
    # Return to the git repo.
    - cd $TRAVIS_REPO_SLUG
+   # Get the version.
+   - VERSION=`python setup.py --version`
+   - echo $VERSION
    # Create the test environment and install dependencies.
    - conda create --use-local -n testenv python=$PYTHON_VERSION
    - source activate testenv

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ boost_dep = ["boost >= 1.56"]
 boost_dep = (boost_dep if sys.argv[1] == "bdist_conda" else [])
 
 setup_requires = cython_dep + numpy_dep
-setup_requires = [] if sys.argv[1] == "bdist_conda" else setup_requires
+setup_requires = setup_requires if (sys.argv[1].startswith("bdist") or
+                                    sys.argv[1].startswith("build") or
+                                    sys.argv[1].startswith("install")) else []
 build_requires = cython_dep + numpy_dep + boost_dep
 install_requires = numpy_dep + boost_dep
 install_requires += [] if sys.argv[1] == "bdist_conda" else cython_dep


### PR DESCRIPTION
Was not always running on the right version of the package so benchmarking was inaccurate. This fixes that problem by ensuring the correct version is installed for benchmarking.