### PR TITLE
Resolves a build issue on Mac when using Python 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,6 @@ if(${USE_CYTHON})
     add_custom_target(
         rank_filter
         ALL
-        COMMAND ${PYTHON_EXECUTABLE} setup.py build
         COMMAND ${PYTHON_EXECUTABLE} setup.py test
         DEPENDS check
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/rank_filter/issues/51

There appears to be a race condition on Mac when building with Python 3.5. As running the tests will build the library, the build step can simply be dropped. This appears to fix it.