### PR TITLE
C-contiguous optimizations/enforcement and other optimizations

### DIFF
--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -14,8 +14,8 @@ cdef extern from "rank_filter_base.hxx" namespace "rank_filter":
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
-cdef inline void lineRankOrderFilter1D_floating(floating[:] src,
-                                                floating[:] dest,
+cdef inline void lineRankOrderFilter1D_floating(floating[::1] src,
+                                                floating[::1] dest,
                                                 size_t half_length,
                                                 double rank) nogil:
     cdef floating* src_begin = &src[0]

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -74,8 +74,7 @@ def lineRankOrderFilter(image,
         out_strip = out_swap[each_slice]
         lineRankOrderFilter1D(out_strip, out_strip)
 
-    out_swap = out_swap.swapaxes(-1, axis).copy()
-    out[...] = out_swap
+    out[...] = out_swap.swapaxes(-1, axis)
 
 
     return(out)

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -65,7 +65,7 @@ def lineRankOrderFilter(image,
             "Only `float32` and `float64` are supported for `image` and `out`."
         )
 
-    out_swap = out.swapaxes(axis, -1).copy()
+    out_swap = numpy.ascontiguousarray(out.swapaxes(axis, -1))
     out_strip = None
 
     for each_slice in itertools.product(*[

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -47,7 +47,8 @@ def lineRankOrderFilter(image,
     else:
         assert (image.dtype == out.dtype), \
                 "Both `image` and `out` must have the same type."
-        out[...] = image
+        if id(image) != id(out):
+            out[...] = image
 
     lineRankOrderFilter1D = None
     if out.dtype.type == numpy.float32:

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -47,6 +47,8 @@ def lineRankOrderFilter(image,
     else:
         assert (image.dtype == out.dtype), \
                 "Both `image` and `out` must have the same type."
+        assert (image.shape == out.shape), \
+                "Both `image` and `out` must have the same shape."
         if id(image) != id(out):
             out[...] = image
 


### PR DESCRIPTION
* Requires that arrays passed to `lineRankOrderFilter1D_floating` are C-contiguous. Will raise a `ValueError` if this is not the case.
* On first axis swap in `lineRankOrderFilter`, ensure the array is C-contiguous instead of always copying. This is a bit faster.
* Instead of copying or ensuring a C-contiguous array simply copy the data from the reswapped array over to the output array.
* Skips copying data to `out` if it is the same object as `image`.