### PR TITLE
Pre C++11 Support

### DIFF
--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -22,8 +22,8 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
         size_t half_length, double rank)
 {
     // Types in use.
-    using T1 = typename std::iterator_traits<I1>::value_type;
-    using T2 = typename std::iterator_traits<I2>::value_type;
+    typedef typename std::iterator_traits<I1>::value_type T1;
+    typedef typename std::iterator_traits<I2>::value_type T2;
 
     // Will ignore boundaries initially.
     // Then will try adding reflection.

--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -2,12 +2,12 @@
 #define __RANK_FILTER_BASE__
 
 
-#include <array>
 #include <deque>
 #include <cassert>
 #include <functional>
 #include <iostream>
 
+#include <boost/array.hpp>
 #include <boost/container/set.hpp>
 #include <boost/container/node_allocator.hpp>
 
@@ -143,7 +143,7 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
 namespace std
 {
     template <class T, size_t N>
-    ostream& operator<<(ostream& out, const array<T, N>& that)
+    ostream& operator<<(ostream& out, const boost::array<T, N>& that)
     {
         out << "{ ";
         for (unsigned int i = 0; i < (N - 1); i++)

--- a/include/rank_filter_vigra.hxx
+++ b/include/rank_filter_vigra.hxx
@@ -4,6 +4,8 @@
 
 #include <iostream>
 
+#include <boost/utility/enable_if.hpp>
+
 #include <vigra/multi_array.hxx>
 
 #include "rank_filter_base.hxx"
@@ -15,7 +17,7 @@ namespace rank_filter
 template<unsigned int N,
         class T1, class S1,
         class T2, class S2,
-        typename std::enable_if<(N == 1), int>::type = 0>
+        typename boost::enable_if_c<(N == 1), int>::type = 0>
 inline void lineRankOrderFilterND(const vigra::MultiArrayView <N, T1, S1> &src,
         vigra::MultiArrayView <N, T2, S2> dest,
         unsigned long half_length, double rank, unsigned int axis = 0)
@@ -31,7 +33,7 @@ inline void lineRankOrderFilterND(const vigra::MultiArrayView <N, T1, S1> &src,
 template<unsigned int N,
         class T1, class S1,
         class T2, class S2,
-        typename std::enable_if<(N > 1), int>::type = 0>
+        typename boost::enable_if_c<(N > 1), int>::type = 0>
 inline void lineRankOrderFilterND(const vigra::MultiArrayView <N, T1, S1> &src,
         vigra::MultiArrayView <N, T2, S2> dest,
         unsigned long half_length, double rank, unsigned int axis = 0)
@@ -91,7 +93,7 @@ inline void lineRankOrderFilter(const vigra::MultiArrayView <N, T1, S1> &src,
 
 namespace vigra {
 
-template <unsigned int N, class T, class S, typename std::enable_if<(N == 1), int>::type = 0>
+template <unsigned int N, class T, class S, typename boost::enable_if_c<(N == 1), int>::type = 0>
 std::ostream& println(std::ostream& out, const vigra::MultiArrayView<N, T, S>& array, unsigned int indent=0)
 {
     for (unsigned int i = 0; i < indent; i++)
@@ -110,7 +112,7 @@ std::ostream& println(std::ostream& out, const vigra::MultiArrayView<N, T, S>& a
 }
 
 
-template <unsigned int N, class T, class S, typename std::enable_if<(N > 1), int>::type = 0>
+template <unsigned int N, class T, class S, typename boost::enable_if_c<(N > 1), int>::type = 0>
 std::ostream& println(std::ostream& out, const vigra::MultiArrayView<N, T, S>& array, unsigned int indent=0)
 {
     for (unsigned int i = 0; i < indent; i++)

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,7 @@ include_dirs = [
 library_dirs = [get_config_var("LIBDIR")]
 sources = glob("src/*.pxd") + glob("src/*.pyx") + glob("src/*.cpp")
 libraries = ["boost_container"]
-extra_compile_args = ["-std=c++11"]
-extra_compile_args += ["-mmacosx-version-min=10.7", "-stdlib=libc++"] \
-                      if sys.platform == "darwin" else []
+extra_compile_args = []
 
 
 setup(

--- a/test/test_rank_filter_base.cxx
+++ b/test/test_rank_filter_base.cxx
@@ -1,7 +1,7 @@
 #define BOOST_TEST_MODULE RankFilterBaseModule
 #include <boost/test/included/unit_test.hpp>
 
-#include <array>
+#include <boost/array.hpp>
 
 
 #include "rank_filter_base.hxx"
@@ -14,20 +14,20 @@ struct RankFilterBaseFixture
 
         static constexpr unsigned long size = 10;
 
-        std::array<double, size> array_1;
-        std::array<double, size> reverse_array_1;
+        boost::array<double, size> array_1;
+        boost::array<double, size> reverse_array_1;
 
-        std::array<double, size> expected_result_1;
-        std::array<double, size> result_1;
+        boost::array<double, size> expected_result_1;
+        boost::array<double, size> result_1;
 
-        std::array<double, size>::iterator array_1_begin;
-        std::array<double, size>::iterator array_1_end;
+        boost::array<double, size>::iterator array_1_begin;
+        boost::array<double, size>::iterator array_1_end;
 
-        std::array<double, size>::iterator reverse_array_1_begin;
-        std::array<double, size>::iterator reverse_array_1_end;
+        boost::array<double, size>::iterator reverse_array_1_begin;
+        boost::array<double, size>::iterator reverse_array_1_end;
 
-        std::array<double, size>::iterator result_1_begin;
-        std::array<double, size>::iterator result_1_end;
+        boost::array<double, size>::iterator result_1_begin;
+        boost::array<double, size>::iterator result_1_end;
 
     public:
 


### PR DESCRIPTION
Changes `rank_filter` to support pre C++11 compilers. As this already requires a relatively recent version of Boost, it is pretty trivial to just get support for the needed features (primarily for testing and VIGRA support) via Boost.