### PR TITLE
Fix VIGRA bindings build on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ else()
     find_package(Boost "1.56.0" REQUIRED COMPONENTS container python)
     find_package(VIGRA REQUIRED)
     set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+    SET(CMAKE_SKIP_RPATH TRUE)
 endif()
 find_package(NUMPY REQUIRED)
 

--- a/test/test_rank_filter_vigra.cxx
+++ b/test/test_rank_filter_vigra.cxx
@@ -1,6 +1,7 @@
 #define BOOST_TEST_MODULE RankFilterVigraModule
 #include <boost/test/included/unit_test.hpp>
 
+#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
 
 #include "rank_filter_vigra.hxx"
 


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/rank_filter/issues/63

* Works around an old known issue on Mac that appears to be triggered by the recent version of Boost. ( http://stackoverflow.com/a/31665947 )
* Works around an issue with CMake where it mucks with RPATHs of libraries and breaks them. ( http://stackoverflow.com/a/25710283 )

More details can be found in the issue ( https://github.com/nanshe-org/rank_filter/issues/63 ).