### PR TITLE
Try to fix package so includes show up in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include _version.py
+include include/*.hxx


### PR DESCRIPTION
Appears the includes are not being packaged in the sdist. This attempts to fix this.