### PR TITLE
Include the license file in packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include _version.py
 include include/*.hxx
+include LICENSE.txt

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -144,6 +144,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - setuptools
     - cmake
     - patchelf >=0.8    # [linux]
     - boost

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -187,7 +187,8 @@ test:
 
 about:
   home: http://github.com/nanshe-org/rank_filter
-  license: 
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
   summary: C++ boosted rank filter with Python bindings.
 
 ## If the app key is present, the package will be an app, meaning it will


### PR DESCRIPTION
When create `sdist`s or other packages, this ensure the license file is included. Appears to work locally. Will create a release with this change after everything passes.