### PR TITLE
Specify the Python version to build against on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 script:
   # Building the recipe will run the tests too.
   - mv .git/shallow .git/shallow-not || true
-  - conda build --no-remove-work-dir rank_filter.recipe
+  - conda build --no-remove-work-dir --python $PYTHON_VERSION rank_filter.recipe
   - mv .git/shallow-not .git/shallow || true
   # Run the benchmarks.
   - conda install --use-local -n testenv rank_filter==$VERSION


### PR DESCRIPTION
When building with `conda-build` on Travis CI, be sure to specify the version of Python to use for building. This avoids any ambiguity or any fallback to some default version.