### PR TITLE
Drop cleanup step from `conda-build` recipe.

### DIFF
--- a/rank_filter.recipe/build.sh
+++ b/rank_filter.recipe/build.sh
@@ -69,6 +69,3 @@ eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make -j${CPU_COUNT}
 
 # "install" to the build prefix (conda will relocate these files afterwards)
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make install
-
-# Clean up any loose ends including CMake files.
-make reset


### PR DESCRIPTION
As `conda-build` will handle cleanup anyways, there is no need for us to do any cleanup after the build ourselves. Plus this step seems to be running into issues for whatever reason. Thus we drop this unneeded step.