### PR TITLE
Drop `.cpp` from our globbed sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ include_dirs = [
     get_python_inc()
 ]
 library_dirs = [get_config_var("LIBDIR")]
-sources = glob("src/*.pxd") + glob("src/*.pyx") + glob("src/*.cpp")
+sources = glob("src/*.pxd") + glob("src/*.pyx")
 libraries = ["boost_container"]
 extra_compile_args = []
 


### PR DESCRIPTION
We don't actually have any `.cpp` files in our globbed sources. Nor would we want to use them if we did. Thus this drops them from our source search.