### PR TITLE
Tidy up Python inspection

### DIFF
--- a/cmake/modules/FindPYTHON.cmake
+++ b/cmake/modules/FindPYTHON.cmake
@@ -25,7 +25,7 @@ IF(PYTHONINTERP_FOUND)
     ENDIF()
     IF(NOT PYTHON_INCLUDE_DIR)
         execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c
-                            "import distutils; import distutils.sysconfig; print(distutils.sysconfig.get_python_inc())"
+                            "from distutils import sysconfig; print(sysconfig.get_python_inc())"
                             RESULT_VARIABLE PYTHON_INCLUDE_DIR_NOT_FOUND
                             OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
                             OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -37,7 +37,7 @@ IF(PYTHONINTERP_FOUND)
     ENDIF()
     IF(NOT PYTHON_LIBRARY_DIR)
         execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c
-                            "import distutils; import distutils.sysconfig; print(distutils.sysconfig.get_config_var(\"LIBDIR\"))"
+                            "from distutils import sysconfig; print(sysconfig.get_config_var(\"LIBDIR\"))"
                             RESULT_VARIABLE PYTHON_LIBRARY_DIR_NOT_FOUND
                             OUTPUT_VARIABLE PYTHON_LIBRARY_DIR
                             OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -49,7 +49,7 @@ IF(PYTHONINTERP_FOUND)
     ENDIF()
     IF(NOT PYTHON_SITE_PACKAGES)
         execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c
-                            "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
+                            "from distutils import sysconfig; print(sysconfig.get_python_lib())"
                             RESULT_VARIABLE PYTHON_SITE_PACKAGES_NOT_FOUND
                             OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
                             OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -61,7 +61,7 @@ IF(PYTHONINTERP_FOUND)
     ENDIF()
     IF(NOT PYTHON_VERSION)
         execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c
-                            "from distutils.sysconfig import get_python_version; print(get_python_version())"
+                            "from distutils import sysconfig; print(sysconfig.get_python_version())"
                             RESULT_VARIABLE PYTHON_VERSION_NOT_FOUND
                             OUTPUT_VARIABLE PYTHON_VERSION
                             OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Uses some more compact `import`s with `distutils` when trying to detect certain features about the active Python interpreter.