### PR TITLE
Support Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,122 @@
+environment:
+
+  matrix:
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 113
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 113
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 113
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 113
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
+
+
+# We always use a 64-bit machine, but can build x86 distributions
+# with the TARGET_ARCH variable.
+platform:
+    - x64
+
+install:
+    # If there is a newer build queued for the same PR, cancel this one.
+    - cmd: |
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
+        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        del ff_ci_pr_build.py
+
+    # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
+    - cmd: rmdir C:\cygwin /s /q
+
+    # Force input and output streams to flush immediately.
+    # Also use binary mode, which is sometimes needed on Windows.
+    - cmd: set PYTHONUNBUFFERED=1
+
+    # AppVeyor gives us 2 cores to work with.
+    #
+    # ref: https://www.appveyor.com/docs/build-environment/#build-vm-configurations
+    - set CPU_COUNT=2
+
+    # Use a small path for conda-build's working directory.
+    - set "CONDA_BLD_PATH=C:\\bld\\"
+
+    # Add path, activate `conda` and update conda.
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
+
+    # Configure conda.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --set auto_update_conda false
+    - conda config --set add_pip_as_python_dependency false
+
+    # Add our channels.
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Update and install everything.
+    - cmd: conda update --all --quiet --yes
+    - cmd: conda install --quiet --yes jinja2 conda-build
+
+    # Patch VS 2008 for 64-bit support.
+    - cmd: conda install --quiet --yes vs2008_express_vc_python_patch
+    - cmd: call setup_x64
+
+    # Show info about conda install.
+    - cmd: conda info
+    - cmd: conda config --get
+
+# Skip .NET project specific build phase.
+build: off
+
+test_script:
+    - conda build rank_filter.recipe --quiet

--- a/cmake/modules/FindPYTHON.cmake
+++ b/cmake/modules/FindPYTHON.cmake
@@ -37,7 +37,7 @@ IF(PYTHONINTERP_FOUND)
     ENDIF()
     IF(NOT PYTHON_LIBRARY_DIR)
         execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c
-                            "from distutils import sysconfig; print(sysconfig.get_config_var(\"LIBDIR\"))"
+                            "from distutils import sysconfig; print(sysconfig.get_config_vars()[\"LIBDIR\"])"
                             RESULT_VARIABLE PYTHON_LIBRARY_DIR_NOT_FOUND
                             OUTPUT_VARIABLE PYTHON_LIBRARY_DIR
                             OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -73,7 +73,7 @@ IF(PYTHONINTERP_FOUND)
     ENDIF()
     IF(NOT PYTHON_LIBRARY_DIR_NOT_FOUND AND NOT PYTHON_VERSION_NOT_FOUND)
         execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c
-		            "from distutils import sysconfig; print(sysconfig.get_config_var(\"LDLIBRARY\"))"
+                            "from distutils import sysconfig; print(sysconfig.get_config_vars()[\"LDLIBRARY\"])"
                             RESULT_VARIABLE PYTHON_LIBRARY_NAME_NOT_FOUND
                             OUTPUT_VARIABLE PYTHON_LIBRARY_NAME
                             OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/rank_filter.recipe/bld.bat
+++ b/rank_filter.recipe/bld.bat
@@ -1,0 +1,18 @@
+:: Configure, build, and install
+mkdir build && cd build
+if errorlevel 1 exit 1
+
+cmake -G "NMake Makefiles"                         ^
+      -DCMAKE_BUILD_TYPE:STRING="Release"          ^
+      -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"  ^
+      -DBOOST_ROOT:PATH="%LIBRARY_PREFIX%"         ^
+      -DVIGRA_ROOT:PATH="%LIBRARY_PREFIX%"         ^
+      -DPYTHON_EXECUTABLE:PATH="%PYTHON%"          ^
+      "%SRC_DIR%"
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,10 @@ include_dirs = [
     os.path.dirname(get_python_inc()),
     get_python_inc()
 ]
-library_dirs = [get_config_var("LIBDIR")]
+library_dirs = list(filter(
+    lambda v: v is not None,
+    [get_config_var("LIBDIR")]
+))
 sources = glob("src/*.pxd") + glob("src/*.pyx")
 libraries = ["boost_container"]
 extra_compile_args = []

--- a/setup.py
+++ b/setup.py
@@ -89,13 +89,13 @@ setup(
     description="A simple python module containing an in-place linear rank"
                 " filter optimized in C++.",
     long_description=readme(),
-    platforms=['Linux'],
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
         'Programming Language :: C++',
         'Programming Language :: Cython',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,28 @@ library_dirs = list(filter(
     [get_config_var("LIBDIR")]
 ))
 sources = glob("src/*.pxd") + glob("src/*.pyx")
-libraries = ["boost_container"]
+
+libraries = []
+if os.name == "posix":
+    libraries.append("boost_container")
+elif os.name == "nt":
+    libname = "boost_container"
+    if sys.version_info[:2] == (2, 7):
+        libname += "-vc90-mt"
+    elif sys.version_info[:2] == (3, 4):
+        libname += "-vc100-mt"
+    elif sys.version_info[:2] >= (3, 5):
+        libname += "-vc140-mt"
+
+    path = os.environ.get("LIB", "").split(";")
+
+    libmatches = sum(
+        list(glob(os.path.join(p, "%s*.lib" % libname)) for p in path), []
+    )
+    library_dirs.append(os.path.dirname(libmatches[0]))
+    libraries.append(os.path.splitext(os.path.basename(libmatches[0]))[0])
+
+
 extra_compile_args = []
 
 


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/rank_filter/issues/104
Closes https://github.com/nanshe-org/rank_filter/pull/70

This is an attempt to add Windows support for `rank_filter`. It should hopefully not be too difficult as this makes use of CMake and Cython. Also all of the dependencies are support on Windows. However, from past experience, the trickiest parts were just getting the package to build on Windows. So this includes AppVeyor CI both to make sure that we can build on Windows and will remain able to in the future.