### PR TITLE
Use Boost's round

### DIFF
--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -10,6 +10,7 @@
 #include <boost/array.hpp>
 #include <boost/container/set.hpp>
 #include <boost/container/node_allocator.hpp>
+#include <boost/math/special_functions/round.hpp>
 
 
 namespace rank_filter
@@ -28,7 +29,7 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     // Rank must be in the range 0 to 1
     assert((0 <= rank) && (rank <= 1));
 
-    const size_t rank_pos = round(rank * (2 * half_length));
+    const size_t rank_pos = static_cast<size_t>(boost::math::round(rank * (2 * half_length)));
 
     // The position of the window.
     size_t window_begin = 0;


### PR DESCRIPTION
It appears the code in the base header file is relying on a `round` implementation to be pulled in by something else. However this may be an implementation that requires C++11 support. To correct this, make use of Boost's `round`. This should be guaranteed to work on incredibly old compilers and avoid accidentally adding a C++11 hard requirement.