### PR TITLE
Use distance function to find iterator separation

### DIFF
--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <functional>
 #include <iostream>
+#include <iterator>
 
 #include <boost/array.hpp>
 #include <boost/container/set.hpp>
@@ -35,8 +36,8 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     size_t window_begin = 0;
 
     // Lengths.
-    const typename std::iterator_traits<I1>::difference_type src_size = src_end - src_begin;
-    const typename std::iterator_traits<I2>::difference_type dest_size = dest_end - dest_begin;
+    const typename std::iterator_traits<I1>::difference_type src_size = std::distance(src_begin, src_end);
+    const typename std::iterator_traits<I2>::difference_type dest_size = std::distance(dest_begin, dest_end);
 
     typedef boost::container::multiset< T1,
             std::less<T1>,


### PR DESCRIPTION
Instead of just starting with subtraction of iterators, use the `std::distance` function, which is a bit more robust when iterator subtraction won't work. Also in cases where iterator subtraction will work, it goes right ahead with it. May also avoid some pesky compiler warnings.