### PR TITLE
Standardize template types

### DIFF
--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -26,6 +26,8 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     // Types in use.
     typedef typename std::iterator_traits<I1>::value_type T1;
     typedef typename std::iterator_traits<I2>::value_type T2;
+    typedef typename std::iterator_traits<I1>::difference_type I1_diff_t;
+    typedef typename std::iterator_traits<I2>::difference_type I2_diff_t;
 
     // Rank must be in the range 0 to 1
     assert((0 <= rank) && (rank <= 1));

--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -38,8 +38,8 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     size_t window_begin = 0;
 
     // Lengths.
-    const typename std::iterator_traits<I1>::difference_type src_size = std::distance(src_begin, src_end);
-    const typename std::iterator_traits<I2>::difference_type dest_size = std::distance(dest_begin, dest_end);
+    const I1_diff_t src_size = std::distance(src_begin, src_end);
+    const I2_diff_t dest_size = std::distance(dest_begin, dest_end);
 
     typedef boost::container::multiset< T1,
             std::less<T1>,

--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -12,6 +12,8 @@
 #include <boost/container/set.hpp>
 #include <boost/container/node_allocator.hpp>
 #include <boost/math/special_functions/round.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits.hpp>
 
 
 namespace rank_filter
@@ -28,6 +30,11 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     typedef typename std::iterator_traits<I2>::value_type T2;
     typedef typename std::iterator_traits<I1>::difference_type I1_diff_t;
     typedef typename std::iterator_traits<I2>::difference_type I2_diff_t;
+
+    // Establish common types to work with source and destination values.
+    BOOST_STATIC_ASSERT((boost::is_same<T1, T2>::value));
+    typedef T1 T;
+    typedef typename boost::common_type<I1_diff_t, I2_diff_t>::type I_diff_t;
 
     // Rank must be in the range 0 to 1
     assert((0 <= rank) && (rank <= 1));

--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -39,18 +39,18 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     // Rank must be in the range 0 to 1
     assert((0 <= rank) && (rank <= 1));
 
-    const size_t rank_pos = static_cast<size_t>(boost::math::round(rank * (2 * half_length)));
+    const I_diff_t rank_pos = static_cast<I_diff_t>(boost::math::round(rank * (2 * half_length)));
 
     // The position of the window.
-    size_t window_begin = 0;
+    I_diff_t window_begin = 0;
 
     // Lengths.
-    const I1_diff_t src_size = std::distance(src_begin, src_end);
-    const I2_diff_t dest_size = std::distance(dest_begin, dest_end);
+    const I_diff_t src_size = std::distance(src_begin, src_end);
+    const I_diff_t dest_size = std::distance(dest_begin, dest_end);
 
-    typedef boost::container::multiset< T1,
-            std::less<T1>,
-            boost::container::node_allocator<T1>,
+    typedef boost::container::multiset< T,
+            std::less<T>,
+            boost::container::node_allocator<T>,
             boost::container::tree_assoc_options< boost::container::tree_type<boost::container::scapegoat_tree> >::type> multiset;
 
     typedef std::deque< typename multiset::iterator > deque;
@@ -60,25 +60,25 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
 
     // Get the initial sorted window.
     // Include the reflection.
-    for (size_t j = half_length; j > 0; j--)
+    for (I_diff_t j = half_length; j > 0; j--)
     {
         window_iters.push_back(sorted_window.insert(src_begin[window_begin + j]));
     }
-    for (size_t j = 0; j <= half_length; j++)
+    for (I_diff_t j = 0; j <= half_length; j++)
     {
         window_iters.push_back(sorted_window.insert(src_begin[window_begin + j]));
     }
 
     typename multiset::iterator rank_point = sorted_window.begin();
 
-    for (size_t i = 0; i < rank_pos; i++)
+    for (I_diff_t i = 0; i < rank_pos; i++)
     {
         rank_point++;
     }
 
     typename multiset::iterator prev_iter;
-    T1 prev_value;
-    T1 next_value;
+    T prev_value;
+    T next_value;
     while ( window_begin < src_size )
     {
         dest_begin[window_begin] = *rank_point;


### PR DESCRIPTION
This standardizes the value type and difference type used in the filter. Also adds a compile time check to verify that no casting is occurring as a result of running the filter. This cleans up some of the lengthy template based types. Also clears up how indices and iterator lengths are handled.