### PR TITLE
Handle filter window reaching end of source

### DIFF
--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -89,7 +89,11 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
 
         window_begin++;
 
-        if ( window_begin < (src_size - half_length) )
+        if ( window_begin == src_size )
+        {
+            next_value = prev_value;
+        }
+        else if ( window_begin < (src_size - half_length) )
         {
             next_value = src_begin[window_begin + half_length];
         }


### PR DESCRIPTION
Previously the rank filter relied on not explicitly supported behavior of libstdc++ and libc++, which was not guaranteed in the C++ standard. Namely that a negative index could be permissible and could retrieve values that had already been popped from the deque. However this isn't a good thing to rely on given the C++ standard does not provide for this. Further some C++ libraries like VC++ actually don't support this behavior and error instead.

To fix this issue, we explicitly store the previously stored value dropped from the window into the next value for this case. This explicitly provides the same behavior that libstdc++ and libc++, but without relying on undefined behavior of deque. Thus this should work well with VC++ and generally be a more robust strategy for handling this case going forward.