### PR TITLE
Simplify the wraparound mirroring index math

### DIFF
--- a/include/rank_filter_base.hxx
+++ b/include/rank_filter_base.hxx
@@ -99,7 +99,7 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
         }
         else
         {
-            next_value = *(window_iters[window_iters.size() + 2*src_size - 2*(window_begin + half_length) - 2]);
+            next_value = *(window_iters[(2 * (src_size - (window_begin + 1)))]);
         }
 
         if ( ( *rank_point < prev_value ) && ( *rank_point <= next_value ) )


### PR DESCRIPTION
Given we know exactly how big the window is when finding the index of the mirrored value, we don't need to check what it is in this step. Instead we know it is `2 * half_length` as it would normally be `2 * half_length + 1`, but we popped one value from the queue so it is `1` less. Once we substitute this in and do a bit of simplification, we get this much simpler result for the needed index. In addition to factoring, we can gather the terms that are being subtracted to ensure that we create the largest possible positive values before taking the difference. In addition to this being simpler, this avoids some overflow issues that VC++ ran into when trying to compute the index.