### PR TITLE
Require the VIGRA tests pass on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ env:
     - PYTHON_VERSION="3.4"
     - PYTHON_VERSION="3.5"
     - PYTHON_VERSION="3.6"
-matrix:
-  allow_failures:
-    - env: PYTHON_VERSION="2.7" TST_VIGRA="true"
 before_install:
   # Move out of git directory to build root.
   - git fetch --unshallow --tags


### PR DESCRIPTION
Readds the requirement that VIGRA pass on Travis CI now that VIGRA has been rebuilt in conda-forge for the newest version of Boost.