### PR TITLE
Drop Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   matrix:
     - PYTHON_VERSION="2.7" TST_VIGRA="true"
     - PYTHON_VERSION="2.7"
-    - PYTHON_VERSION="3.4"
     - PYTHON_VERSION="3.5"
     - PYTHON_VERSION="3.6"
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         'Programming Language :: Cython',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering',


### PR DESCRIPTION
Removes Python 3.4 support as it is too difficult to maintain at this point and we are not actively using that Python version.