### PR TITLE
Use conda-build compiler syntax in recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
-language: c++
-compiler: gcc
+language: generic
 sudo: false
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
 env:
   matrix:
     - PYTHON_VERSION="2.7"
@@ -20,9 +12,6 @@ before_install:
   - cd ../..
   - pwd
 install:
-  # Update C/C++ compilers to something with C++11 features.
-  - export EXT_CC=/usr/bin/gcc-4.8
-  - export EXT_CXX=/usr/bin/g++-4.8
   # Download and configure conda.
   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1} | grep 3`-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/rank_filter.recipe/build.sh
+++ b/rank_filter.recipe/build.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-# Override the compiler
-if [ ! -z "${EXT_CC}" ];
-then
-    CC="${EXT_CC}"
-fi
-
-if [ ! -z "${EXT_CXX}" ];
-then
-    CXX="${EXT_CXX}"
-fi
-
 # Configure, build, and install
 mkdir build && cd build
 cmake "${SRC_DIR}" \

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -14,10 +14,12 @@ build:
 
 requirements:
   build:
-    - toolchain
-    - setuptools
+    - {{ compiler("cxx") }}
     - cmake
     - patchelf >=0.8    # [linux]
+
+  host:
+    - setuptools
     - boost-cpp
     - python
     - numpy 1.11.*

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -5,9 +5,6 @@ package:
 source:
   git_url: ..
 
-build:
-  detect_binary_files_with_prefix: true
-
 requirements:
   build:
     - {{ compiler("cxx") }}

--- a/rank_filter.recipe/meta.yaml
+++ b/rank_filter.recipe/meta.yaml
@@ -6,10 +6,6 @@ source:
   git_url: ..
 
 build:
-  script_env:
-    - EXT_CC
-    - EXT_CXX
-
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
Update the `conda-build` recipe to use the `compiler` syntax and cleanup some outdated stuff. Also streamline the CI build as a result of this change.