### PR TITLE
Fix Cython `half_length` type to `size_t`

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -9,7 +9,7 @@ include "version.pxi"
 
 @cython.boundscheck(False)
 def lineRankOrderFilter(image,
-                        int half_length,
+                        size_t half_length,
                         double rank,
                         int axis=-1,
                         out=None):
@@ -19,7 +19,7 @@ def lineRankOrderFilter(image,
         Args:
             image(numpy.ndarray):      array to run the rank filter over.
 
-            half_window_size(int):     half the window size for the kernel.
+            half_window_size(size_t):  half the window size for the kernel.
 
             rank(double):              quantile to use from ``0.0`` to ``1.0``.
 


### PR DESCRIPTION
At the C++ level we treat the `half_length`'s type as `size_t`, so it is a little strange to make it `int` at the Python interface level. This fixes it to be `size_t` here as well.