### PR TITLE
Use Python 3 division on Python 2

### DIFF
--- a/src/benchmark_rank_filter.py
+++ b/src/benchmark_rank_filter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import division
 
 import sys
 import timeit


### PR DESCRIPTION
Make sure that floating point division is used on Python 2. This basically happens anyways as we have a floating point value divided by an integral value. Still it is good to ensure that our average doesn't get truncated by accident.