### PR TITLE
Fix `half_length` name in `lineRankOrderFilter`

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -19,7 +19,7 @@ def lineRankOrderFilter(image,
         Args:
             image(numpy.ndarray):      array to run the rank filter over.
 
-            half_window_size(size_t):  half the window size for the kernel.
+            half_length(size_t):       half the window size for the kernel.
 
             rank(double):              quantile to use from ``0.0`` to ``1.0``.
 


### PR DESCRIPTION
Was called `half_window_size` previously, but is everywhere else called `half_length`. This fixes that discrepancy.