### PR TITLE
Simplify fused type wrapper `lambda`

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -53,14 +53,10 @@ def lineRankOrderFilter(image,
     lineRankOrderFilter1D = None
     if out.dtype.type == numpy.float32:
         lineRankOrderFilter1D = lambda a1, a2: \
-            lineRankOrderFilter1D_floating[float](
-                a1, a2, half_length, rank
-            )
+            lineRankOrderFilter1D_floating[float](a1, a2, half_length, rank)
     elif out.dtype.type == numpy.float64:
         lineRankOrderFilter1D = lambda a1, a2: \
-            lineRankOrderFilter1D_floating[double](
-                a1, a2, half_length, rank
-            )
+            lineRankOrderFilter1D_floating[double](a1, a2, half_length, rank)
     else:
         raise TypeError(
             "Only `float32` and `float64` are supported for `image` and `out`."

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -53,12 +53,12 @@ def lineRankOrderFilter(image,
     lineRankOrderFilter1D = None
     if out.dtype.type == numpy.float32:
         lineRankOrderFilter1D = lambda a1, a2: \
-            lineRankOrderFilter1D_floating[cython.float](
+            lineRankOrderFilter1D_floating[float](
                 a1, a2, half_length, rank
             )
     elif out.dtype.type == numpy.float64:
         lineRankOrderFilter1D = lambda a1, a2: \
-            lineRankOrderFilter1D_floating[cython.double](
+            lineRankOrderFilter1D_floating[double](
                 a1, a2, half_length, rank
             )
     else:


### PR DESCRIPTION
Drops the usage of `cython` from the type selection of the fused type wrapper `lambda` calls.