### PR TITLE
Use NumPy's `copyto` to copy `image` to `out`

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -47,8 +47,7 @@ def lineRankOrderFilter(image,
                 "Both `image` and `out` must have the same type."
         assert (image.shape == out.shape), \
                 "Both `image` and `out` must have the same shape."
-        if id(image) != id(out):
-            out[...] = image
+        numpy.copyto(out, image)
 
     lineRankOrderFilter1D = None
     if out.dtype.type == numpy.float32:

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -69,7 +69,7 @@ def lineRankOrderFilter(image,
         out_strip = out_swap[idx]
         lineRankOrderFilter1D(out_strip, out_strip)
 
-    out[...] = out_swap.swapaxes(-1, axis)
+    numpy.copyto(out, out_swap.swapaxes(-1, axis))
 
 
     return(out)


### PR DESCRIPTION
Drop the `id` check and just use NumPy's `copyto`. Internally NumPy checks to see if this `out` is the same as `image`, so there is no need for us to do this explicitly as we gain this optimization for free.