### PR TITLE
Use ndarray type

### DIFF
--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -1,6 +1,8 @@
 cimport cython
 from cython cimport floating
 
+cimport numpy
+
 
 cdef extern from "rank_filter.hxx" namespace "rank_filter":
     void lineRankOrderFilter1D[I1, I2](const I1& src_begin,
@@ -23,3 +25,21 @@ cdef inline void lineRankOrderFilter1D_floating_inplace(floating[::1] a,
     lineRankOrderFilter1D(
         a_begin, a_end, a_begin, a_end, half_length, rank
     )
+
+
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+@cython.nonecheck(False)
+cdef inline bint ndindex(const numpy.npy_intp[:] shape,
+                         numpy.npy_intp[:] pos) nogil:
+    cdef Py_ssize_t i = shape.shape[0]
+    while i > 0:
+        i -= 1
+        pos[i] += 1
+
+        if pos[i] < shape[i]:
+            return False
+        elif i > 0:
+            pos[i] = 0
+
+    return True

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -38,10 +38,8 @@ def lineRankOrderFilter(image not None,
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
-    cdef numpy.ndarray image_arr
-    cdef numpy.ndarray out_arr
-
-    image = numpy.asarray(image)
+    cdef numpy.ndarray image_arr = numpy.asarray(image)
+    cdef numpy.ndarray out_arr = out
 
     assert ((half_length + 1) <= image.shape[axis]), \
             "Window must be no bigger than the image."
@@ -50,7 +48,7 @@ def lineRankOrderFilter(image not None,
             "The rank must be between 0.0 and 1.0."
 
     if out is None:
-        out = image.copy()
+        out = out_arr = image.copy()
     else:
         assert (image.dtype == out.dtype), \
                 "Both `image` and `out` must have the same type."

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -54,7 +54,7 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     if out is None:
         out = numpy.PyArray_NewCopy(image, numpy.NPY_CORDER)
     else:
-        assert (image.descr.type_num == out.descr.type_num), \
+        assert (numpy.PyArray_TYPE(image) == numpy.PyArray_TYPE(out)), \
                 "Both `image` and `out` must have the same type."
         assert numpy.PyArray_SAMESHAPE(image, out), \
                 "Both `image` and `out` must have the same shape."
@@ -66,12 +66,13 @@ def lineRankOrderFilter(numpy.ndarray image not None,
 
     out_strip_indices = numpy.ndindex((<object>out_swap).shape[:-1])
 
-    if out.descr.type_num == numpy.NPY_FLOAT32:
+    cdef int out_type_num = numpy.PyArray_TYPE(out)
+    if out_type_num == numpy.NPY_FLOAT32:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[float](
                 out_swap[idx], half_length, rank
             )
-    elif out.descr.type_num == numpy.NPY_FLOAT64:
+    elif out_type_num == numpy.NPY_FLOAT64:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[double](
                 out_swap[idx], half_length, rank

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -7,6 +7,8 @@ import numpy
 
 include "version.pxi"
 
+numpy.import_array()
+
 
 @cython.boundscheck(False)
 def lineRankOrderFilter(image not None,

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -54,7 +54,8 @@ def lineRankOrderFilter(image not None,
                 "Both `image` and `out` must have the same type."
         assert numpy.PyArray_SAMESHAPE(image_arr, out_arr), \
                 "Both `image` and `out` must have the same shape."
-        numpy.copyto(out, image)
+        if numpy.PyArray_CopyInto(out_arr, image_arr) == -1:
+            raise RuntimeError("Unable to copy `image` to `out`.")
 
     out_swap = numpy.ascontiguousarray(out.swapaxes(axis, -1))
     out_strip_indices = numpy.ndindex(out_swap.shape[:-1])

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -40,6 +40,11 @@ def lineRankOrderFilter(numpy.ndarray image not None,
 
     cdef numpy.ndarray out_swap
 
+    if -image.ndim <= axis < 0:
+        axis += image.ndim
+    elif not (0 <= axis < image.ndim):
+        raise IndexError("`axis` needs to be within `image.ndim`")
+
     assert ((half_length + 1) <= (<object>image).shape[axis]), \
             "Window must be no bigger than the image."
 

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -50,7 +50,7 @@ def lineRankOrderFilter(image not None,
     if out is None:
         out = out_arr = numpy.PyArray_NewCopy(image_arr, numpy.NPY_CORDER)
     else:
-        assert (image.dtype == out.dtype), \
+        assert (image_arr.descr.type_num == out_arr.descr.type_num), \
                 "Both `image` and `out` must have the same type."
         assert (image.shape == out.shape), \
                 "Both `image` and `out` must have the same shape."

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -59,7 +59,9 @@ def lineRankOrderFilter(image not None,
         if numpy.PyArray_CopyInto(out_arr, image_arr) == -1:
             raise RuntimeError("Unable to copy `image` to `out`.")
 
-    out_swap = numpy.ascontiguousarray(out.swapaxes(axis, -1))
+    out_swap = numpy.PyArray_SwapAxes(out, axis, out.ndim - 1)
+    out_swap = numpy.PyArray_GETCONTIGUOUS(out_swap)
+
     out_strip_indices = numpy.ndindex((<object>out_swap).shape[:-1])
 
     if out_arr.descr.type_num == numpy.NPY_FLOAT32:

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -79,6 +79,8 @@ def lineRankOrderFilter(image not None,
             "Only `float32` and `float64` are supported for `image` and `out`."
         )
 
-    numpy.copyto(out, out_swap.swapaxes(-1, axis))
+    out_swap = numpy.PyArray_SwapAxes(out_swap, out.ndim - 1, axis)
+    if numpy.PyArray_CopyInto(out_arr, out_swap) == -1:
+        raise RuntimeError("Unable to copy `out` to `out_swap`.")
 
     return(out)

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -11,11 +11,11 @@ numpy.import_array()
 
 
 @cython.boundscheck(False)
-def lineRankOrderFilter(image not None,
+def lineRankOrderFilter(numpy.ndarray image not None,
                         size_t half_length,
                         double rank,
                         int axis=-1,
-                        out=None):
+                        numpy.ndarray out=None):
     """
         Runs a linear rank filter kernel along one dimension of an array.
 
@@ -38,25 +38,22 @@ def lineRankOrderFilter(image not None,
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
-    cdef numpy.ndarray image_arr = numpy.asarray(image)
-    cdef numpy.ndarray out_arr = out
-
     cdef numpy.ndarray out_swap
 
-    assert ((half_length + 1) <= image.shape[axis]), \
+    assert ((half_length + 1) <= (<object>image).shape[axis]), \
             "Window must be no bigger than the image."
 
     assert (0.0 <= rank <= 1.0), \
             "The rank must be between 0.0 and 1.0."
 
     if out is None:
-        out = out_arr = numpy.PyArray_NewCopy(image_arr, numpy.NPY_CORDER)
+        out = numpy.PyArray_NewCopy(image, numpy.NPY_CORDER)
     else:
-        assert (image_arr.descr.type_num == out_arr.descr.type_num), \
+        assert (image.descr.type_num == out.descr.type_num), \
                 "Both `image` and `out` must have the same type."
-        assert numpy.PyArray_SAMESHAPE(image_arr, out_arr), \
+        assert numpy.PyArray_SAMESHAPE(image, out), \
                 "Both `image` and `out` must have the same shape."
-        if numpy.PyArray_CopyInto(out_arr, image_arr) == -1:
+        if numpy.PyArray_CopyInto(out, image) == -1:
             raise RuntimeError("Unable to copy `image` to `out`.")
 
     out_swap = numpy.PyArray_SwapAxes(out, axis, out.ndim - 1)
@@ -64,12 +61,12 @@ def lineRankOrderFilter(image not None,
 
     out_strip_indices = numpy.ndindex((<object>out_swap).shape[:-1])
 
-    if out_arr.descr.type_num == numpy.NPY_FLOAT32:
+    if out.descr.type_num == numpy.NPY_FLOAT32:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[float](
                 out_swap[idx], half_length, rank
             )
-    elif out_arr.descr.type_num == numpy.NPY_FLOAT64:
+    elif out.descr.type_num == numpy.NPY_FLOAT64:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[double](
                 out_swap[idx], half_length, rank
@@ -80,7 +77,7 @@ def lineRankOrderFilter(image not None,
         )
 
     out_swap = numpy.PyArray_SwapAxes(out_swap, out.ndim - 1, axis)
-    if numpy.PyArray_CopyInto(out_arr, out_swap) == -1:
+    if numpy.PyArray_CopyInto(out, out_swap) == -1:
         raise RuntimeError("Unable to copy `out` to `out_swap`.")
 
     return(out)

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -60,7 +60,7 @@ def lineRankOrderFilter(image not None,
             raise RuntimeError("Unable to copy `image` to `out`.")
 
     out_swap = numpy.ascontiguousarray(out.swapaxes(axis, -1))
-    out_strip_indices = numpy.ndindex(out_swap.shape[:-1])
+    out_strip_indices = numpy.ndindex((<object>out_swap).shape[:-1])
 
     if out_arr.descr.type_num == numpy.NPY_FLOAT32:
         for idx in out_strip_indices:

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -38,6 +38,9 @@ def lineRankOrderFilter(numpy.ndarray image not None,
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
+    cdef int image_type_num = numpy.PyArray_TYPE(image)
+    cdef int out_type_num
+
     cdef numpy.ndarray out_swap
 
     if -image.ndim <= axis < 0:
@@ -53,8 +56,10 @@ def lineRankOrderFilter(numpy.ndarray image not None,
 
     if out is None:
         out = numpy.PyArray_NewCopy(image, numpy.NPY_CORDER)
+        out_type_num = image_type_num
     else:
-        assert (numpy.PyArray_TYPE(image) == numpy.PyArray_TYPE(out)), \
+        out_type_num = numpy.PyArray_TYPE(out)
+        assert (image_type_num == out_type_num), \
                 "Both `image` and `out` must have the same type."
         assert numpy.PyArray_SAMESHAPE(image, out), \
                 "Both `image` and `out` must have the same shape."
@@ -66,7 +71,6 @@ def lineRankOrderFilter(numpy.ndarray image not None,
 
     out_strip_indices = numpy.ndindex((<object>out_swap).shape[:-1])
 
-    cdef int out_type_num = numpy.PyArray_TYPE(out)
     if out_type_num == numpy.NPY_FLOAT32:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[float](

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -38,6 +38,9 @@ def lineRankOrderFilter(image not None,
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
+    cdef numpy.ndarray image_arr
+    cdef numpy.ndarray out_arr
+
     image = numpy.asarray(image)
 
     assert ((half_length + 1) <= image.shape[axis]), \

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -45,7 +45,7 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     elif not (0 <= axis < image.ndim):
         raise IndexError("`axis` needs to be within `image.ndim`")
 
-    assert ((half_length + 1) <= (<object>image).shape[axis]), \
+    assert ((half_length + 1) <= image.shape[axis]), \
             "Window must be no bigger than the image."
 
     assert (0.0 <= rank <= 1.0), \

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -41,6 +41,8 @@ def lineRankOrderFilter(image not None,
     cdef numpy.ndarray image_arr = numpy.asarray(image)
     cdef numpy.ndarray out_arr = out
 
+    cdef numpy.ndarray out_swap
+
     assert ((half_length + 1) <= image.shape[axis]), \
             "Window must be no bigger than the image."
 

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -48,7 +48,7 @@ def lineRankOrderFilter(image not None,
             "The rank must be between 0.0 and 1.0."
 
     if out is None:
-        out = out_arr = image.copy()
+        out = out_arr = numpy.PyArray_NewCopy(image_arr, numpy.NPY_CORDER)
     else:
         assert (image.dtype == out.dtype), \
                 "Both `image` and `out` must have the same type."

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -2,6 +2,7 @@ from rank_filter cimport lineRankOrderFilter1D_floating_inplace
 
 cimport cython
 
+cimport numpy
 import numpy
 
 include "version.pxi"

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -60,12 +60,12 @@ def lineRankOrderFilter(image not None,
     out_swap = numpy.ascontiguousarray(out.swapaxes(axis, -1))
     out_strip_indices = numpy.ndindex(out_swap.shape[:-1])
 
-    if out.dtype.type == numpy.float32:
+    if out_arr.descr.type_num == numpy.NPY_FLOAT32:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[float](
                 out_swap[idx], half_length, rank
             )
-    elif out.dtype.type == numpy.float64:
+    elif out_arr.descr.type_num == numpy.NPY_FLOAT64:
         for idx in out_strip_indices:
             lineRankOrderFilter1D_floating_inplace[double](
                 out_swap[idx], half_length, rank

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -52,7 +52,7 @@ def lineRankOrderFilter(image not None,
     else:
         assert (image_arr.descr.type_num == out_arr.descr.type_num), \
                 "Both `image` and `out` must have the same type."
-        assert (image.shape == out.shape), \
+        assert numpy.PyArray_SAMESHAPE(image_arr, out_arr), \
                 "Both `image` and `out` must have the same shape."
         numpy.copyto(out, image)
 


### PR DESCRIPTION
Types `image` and `out` in `lineRankOrderFilter` as `ndarray`s. Makes use of NumPy's C API internally in a few spots to handle this type change and speed a few things up. Casts `image` and `out` as `object`s in any rough spots to preserve existing code until it can be rewritten properly.