### PR TITLE
Validate image

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -35,6 +35,8 @@ def lineRankOrderFilter(image not None,
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
+    image = numpy.asarray(image)
+
     assert (half_length >= 0), \
             "Window must be non-negative."
     assert ((half_length + 1) <= image.shape[axis]), \

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -8,7 +8,7 @@ include "version.pxi"
 
 
 @cython.boundscheck(False)
-def lineRankOrderFilter(image,
+def lineRankOrderFilter(image not None,
                         size_t half_length,
                         double rank,
                         int axis=-1,


### PR DESCRIPTION
Make sure that `image` is an `ndarray` before proceeding further in `lineRankOrderFilter`. Ensure that `image` is converted to an `ndarray` if possible and if not allow Cython or NumPy to raise as appropriate.