### PR TITLE
Drop check for non-negative `half_length`

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -35,8 +35,6 @@ def lineRankOrderFilter(image,
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
-    assert (half_length >= 0), \
-            "Window must be non-negative."
     assert ((half_length + 1) <= image.shape[axis]), \
             "Window must be no bigger than the image."
 


### PR DESCRIPTION
As the `half_length` is now correctly `size_t`, this check effectively happens when coercing `object`s to `size_t`. So there is no need for this assertion as it will never be used.