### PR TITLE
Refactor reused loop variables

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -82,14 +82,14 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     cdef bint stop = False
     if out_type_num == numpy.NPY_FLOAT32:
         while not stop:
-            out_strip = numpy.PyArray_GetPtr(out_swap, &idx[0])
+            out_strip = numpy.PyArray_GetPtr(out_swap, idx_ptr)
             lineRankOrderFilter1D_floating_inplace[float](
                 <float[:axis_len]>(<float*>out_strip), half_length, rank
             )
             stop = ndindex(out_swap_shape[:-1], idx[:-1])
     elif out_type_num == numpy.NPY_FLOAT64:
         while not stop:
-            out_strip = numpy.PyArray_GetPtr(out_swap, &idx[0])
+            out_strip = numpy.PyArray_GetPtr(out_swap, idx_ptr)
             lineRankOrderFilter1D_floating_inplace[double](
                 <double[:axis_len]>(<double*>out_strip), half_length, rank
             )

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -77,6 +77,7 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     cdef numpy.npy_intp[::1] idx = numpy.PyArray_ZEROS(
         1, &idx_len, numpy.NPY_INTP, 0
     )
+    cdef numpy.npy_intp* idx_ptr = &idx[0]
     cdef void* out_strip
     cdef bint stop = False
     if out_type_num == numpy.NPY_FLOAT32:

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -77,6 +77,8 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     cdef numpy.npy_intp[::1] idx = numpy.PyArray_ZEROS(
         1, &idx_len, numpy.NPY_INTP, 0
     )
+    cdef numpy.npy_intp[::1] out_swap_shape_1 = out_swap_shape[:-1]
+    cdef numpy.npy_intp[::1] idx_1 = idx[:-1]
     cdef numpy.npy_intp* idx_ptr = &idx[0]
     cdef void* out_strip
     cdef bint stop = False

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -88,14 +88,14 @@ def lineRankOrderFilter(numpy.ndarray image not None,
             lineRankOrderFilter1D_floating_inplace[float](
                 <float[:axis_len]>(<float*>out_strip), half_length, rank
             )
-            stop = ndindex(out_swap_shape[:-1], idx[:-1])
+            stop = ndindex(out_swap_shape_1, idx_1)
     elif out_type_num == numpy.NPY_FLOAT64:
         while not stop:
             out_strip = numpy.PyArray_GetPtr(out_swap, idx_ptr)
             lineRankOrderFilter1D_floating_inplace[double](
                 <double[:axis_len]>(<double*>out_strip), half_length, rank
             )
-            stop = ndindex(out_swap_shape[:-1], idx[:-1])
+            stop = ndindex(out_swap_shape_1, idx_1)
     else:
         raise TypeError(
             "Only `float32` and `float64` are supported for `image` and `out`."


### PR DESCRIPTION
Refactor some commonly used expressions out of the `while`-loop and store them as variables for easy use within the `while`-loop. Cuts down on the boilerplate generated and included in the loop especially for things that are being reused.