### PR TITLE
Use float pointers in Cython/C++ binding function

### DIFF
--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -16,11 +16,11 @@ cdef extern from "rank_filter.hxx" namespace "rank_filter":
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
-cdef inline void lineRankOrderFilter1D_floating_inplace(floating[::1] a,
+cdef inline void lineRankOrderFilter1D_floating_inplace(floating* a_begin,
+                                                        size_t a_len,
                                                         size_t half_length,
                                                         double rank) nogil:
-    cdef floating* a_begin = &a[0]
-    cdef floating* a_end = &a[-1] + 1
+    cdef floating* a_end = a_begin + a_len
 
     lineRankOrderFilter1D(
         a_begin, a_end, a_begin, a_end, half_length, rank

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -69,7 +69,7 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     out_swap = numpy.PyArray_SwapAxes(out, axis, out.ndim - 1)
     out_swap = numpy.PyArray_GETCONTIGUOUS(out_swap)
 
-    cdef numpy.npy_intp axis_len = out.shape[axis]
+    cdef size_t axis_len = out.shape[axis]
     cdef numpy.npy_intp idx_len = out_swap.ndim
     cdef numpy.npy_intp[::1] out_swap_shape = <numpy.npy_intp[:idx_len]>(
         out_swap.shape
@@ -83,14 +83,14 @@ def lineRankOrderFilter(numpy.ndarray image not None,
         while not stop:
             out_strip = numpy.PyArray_GetPtr(out_swap, &idx[0])
             lineRankOrderFilter1D_floating_inplace[float](
-                <float[:axis_len]>(<float*>out_strip), half_length, rank
+                <float*>out_strip, axis_len, half_length, rank
             )
             stop = ndindex(out_swap_shape[:-1], idx[:-1])
     elif out_type_num == numpy.NPY_FLOAT64:
         while not stop:
             out_strip = numpy.PyArray_GetPtr(out_swap, &idx[0])
             lineRankOrderFilter1D_floating_inplace[double](
-                <double[:axis_len]>(<double*>out_strip), half_length, rank
+                <double*>out_strip, axis_len, half_length, rank
             )
             stop = ndindex(out_swap_shape[:-1], idx[:-1])
     else:


### PR DESCRIPTION
Change the Cython/C++ binding function, `lineRankOrderFilter1D_floating_inplace`, to accept floating pointers instead of memoryviews. This cuts down the code generated in the `while`-loop to convert the pointer to a memoryview and in the Cython/C++ binding function. Should make it easier for compilers to optimize further as the code is basically straight C at this point. Also should help speed up the `while`-loop a bit more.