### PR TITLE
Refactor single and double precision `while`-loops

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -102,7 +102,7 @@ cdef extern from "numpy/arrayobject.h":
 cdef inline void lineRankOrderFilter1D_floating_inplace_loop(numpy.ndarray out,
                                                              size_t half_length,
                                                              double rank,
-                                                             floating* null):
+                                                             floating* null) nogil:
     cdef size_t axis_len = out.shape[out.ndim - 1]
     cdef numpy.npy_intp idx_len = out.ndim
     cdef numpy.npy_intp idx_len_1 = idx_len - 1

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -103,14 +103,18 @@ cdef inline void lineRankOrderFilter1D_floating_inplace_loop(numpy.ndarray out,
     cdef numpy.npy_intp idx_len = out.ndim
     cdef numpy.npy_intp idx_len_1 = idx_len - 1
 
-    cdef numpy.npy_intp[::1] out_shape = <numpy.npy_intp[:idx_len]>(out.shape)
-    cdef numpy.npy_intp[::1] idx = <numpy.npy_intp[:idx_len]>(
+    cdef numpy.npy_intp* out_shape_ptr = &out.shape[0]
+    cdef numpy.npy_intp* idx_ptr = <numpy.npy_intp*>(
         libc.stdlib.malloc(idx_len * sizeof(numpy.npy_intp))
     )
-    idx[:] = 0
 
-    cdef numpy.npy_intp* out_shape_ptr = &out_shape[0]
-    cdef numpy.npy_intp* idx_ptr = &idx[0]
+    if idx_ptr == NULL:
+        with gil:
+            raise MemoryError("Unable to allocate `idx_ptr`.")
+
+    cdef size_t i = 0
+    for i in range(idx_len):
+        idx_ptr[i] = 0
 
     cdef floating* out_strip = NULL
     cdef bint stop = False

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -92,6 +92,10 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     return(out)
 
 
+cdef extern from "numpy/arrayobject.h":
+    void* PyArray_GetPtr(numpy.ndarray, numpy.npy_intp*) nogil
+
+
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
@@ -119,7 +123,7 @@ cdef inline void lineRankOrderFilter1D_floating_inplace_loop(numpy.ndarray out,
     cdef floating* out_strip = NULL
     cdef bint stop = False
     while not stop:
-        out_strip = <floating*>numpy.PyArray_GetPtr(out, idx_ptr)
+        out_strip = <floating*>PyArray_GetPtr(out, idx_ptr)
         lineRankOrderFilter1D_floating_inplace[floating](
             out_strip, axis_len, half_length, rank
         )

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -1,5 +1,8 @@
 from rank_filter cimport lineRankOrderFilter1D_floating_inplace, ndindex
 
+cimport libc
+cimport libc.stdlib
+
 cimport cython
 
 cimport numpy
@@ -101,9 +104,10 @@ cdef inline void lineRankOrderFilter1D_floating_inplace_loop(numpy.ndarray out,
     cdef numpy.npy_intp idx_len_1 = idx_len - 1
 
     cdef numpy.npy_intp[::1] out_shape = <numpy.npy_intp[:idx_len]>(out.shape)
-    cdef numpy.npy_intp[::1] idx = numpy.PyArray_ZEROS(
-        1, &idx_len, numpy.NPY_INTP, 0
+    cdef numpy.npy_intp[::1] idx = <numpy.npy_intp[:idx_len]>(
+        libc.stdlib.malloc(idx_len * sizeof(numpy.npy_intp))
     )
+    idx[:] = 0
 
     cdef numpy.npy_intp* out_shape_ptr = &out_shape[0]
     cdef numpy.npy_intp* idx_ptr = &idx[0]
@@ -116,3 +120,5 @@ cdef inline void lineRankOrderFilter1D_floating_inplace_loop(numpy.ndarray out,
             out_strip, axis_len, half_length, rank
         )
         stop = ndindex(out_shape_ptr, idx_ptr, idx_len_1)
+
+    libc.stdlib.free(<void*>idx_ptr)


### PR DESCRIPTION
Refactor out common `while`-loops for single and double precision floats into a fused-type function. This combines redundant code between these two branches into one function. Also pulls out a bunch of variables from our top-level function that are only need for this loop cleaning up the code a bit.

Optimizes the fused-type function a bit by making use C memory allocation and similar so that the GIL can be released for the function overall. This can improve performance for things like Dask where an array may be broken into chunks and each chunk's result can be computed without the GIL for nearly the entirety of the function.