### PR TITLE
Simplify looping code and drop unneeded code

### DIFF
--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -25,3 +25,21 @@ cdef inline void lineRankOrderFilter1D_floating_inplace(floating* a_begin,
     lineRankOrderFilter1D(
         a_begin, a_end, a_begin, a_end, half_length, rank
     )
+
+
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+@cython.nonecheck(False)
+cdef inline void lineRankOrderFilter1D_floating_inplace_loop(floating* out_data,
+                                                             numpy.npy_intp out_size,
+                                                             numpy.npy_intp out_step,
+                                                             size_t half_length,
+                                                             double rank) nogil:
+    cdef numpy.npy_intp i
+
+    cdef floating* out_ptr = out_data
+    for i from 0 <= i < out_size by out_step:
+        lineRankOrderFilter1D_floating_inplace[floating](
+            out_ptr, out_step, half_length, rank
+        )
+        out_ptr += out_step

--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -25,22 +25,3 @@ cdef inline void lineRankOrderFilter1D_floating_inplace(floating* a_begin,
     lineRankOrderFilter1D(
         a_begin, a_end, a_begin, a_end, half_length, rank
     )
-
-
-@cython.boundscheck(False)
-@cython.initializedcheck(False)
-@cython.nonecheck(False)
-cdef inline bint ndindex(const numpy.npy_intp* shape,
-                         numpy.npy_intp* pos,
-                         Py_ssize_t n) nogil:
-    cdef Py_ssize_t i = n
-    while i > 0:
-        i -= 1
-        pos[i] += 1
-
-        if pos[i] < shape[i]:
-            return False
-        elif i > 0:
-            pos[i] = 0
-
-    return True

--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -37,9 +37,11 @@ cdef inline void lineRankOrderFilter1D_floating_inplace_loop(floating* out_data,
                                                              double rank) nogil:
     cdef numpy.npy_intp i
 
-    cdef floating* out_ptr = out_data
+    cdef floating* out_begin = out_data
+    cdef floating* out_end = out_data + out_step
     for i from 0 <= i < out_size by out_step:
-        lineRankOrderFilter1D_floating_inplace[floating](
-            out_ptr, out_step, half_length, rank
+        lineRankOrderFilter1D(
+            out_begin, out_end, out_begin, out_end, half_length, rank
         )
-        out_ptr += out_step
+        out_begin += out_step
+        out_end += out_step

--- a/src/rank_filter.pxd
+++ b/src/rank_filter.pxd
@@ -16,20 +16,6 @@ cdef extern from "rank_filter.hxx" namespace "rank_filter":
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 @cython.nonecheck(False)
-cdef inline void lineRankOrderFilter1D_floating_inplace(floating* a_begin,
-                                                        size_t a_len,
-                                                        size_t half_length,
-                                                        double rank) nogil:
-    cdef floating* a_end = a_begin + a_len
-
-    lineRankOrderFilter1D(
-        a_begin, a_end, a_begin, a_end, half_length, rank
-    )
-
-
-@cython.boundscheck(False)
-@cython.initializedcheck(False)
-@cython.nonecheck(False)
 cdef inline void lineRankOrderFilter1D_floating_inplace_loop(floating* out_data,
                                                              numpy.npy_intp out_size,
                                                              numpy.npy_intp out_step,

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -89,10 +89,6 @@ def lineRankOrderFilter(numpy.ndarray image not None,
     return(out)
 
 
-cdef extern from "numpy/arrayobject.h":
-    void* PyArray_GetPtr(numpy.ndarray, numpy.npy_intp*) nogil
-
-
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 @cython.nonecheck(False)

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -1,4 +1,4 @@
-from rank_filter cimport lineRankOrderFilter1D_floating_inplace
+from rank_filter cimport lineRankOrderFilter1D_floating_inplace_loop
 
 cimport cython
 
@@ -91,21 +91,3 @@ def lineRankOrderFilter(numpy.ndarray image not None,
         raise RuntimeError("Unable to copy `out_swap` to `out`.")
 
     return(out)
-
-
-@cython.boundscheck(False)
-@cython.initializedcheck(False)
-@cython.nonecheck(False)
-cdef inline void lineRankOrderFilter1D_floating_inplace_loop(floating* out_data,
-                                                             numpy.npy_intp out_size,
-                                                             numpy.npy_intp out_step,
-                                                             size_t half_length,
-                                                             double rank) nogil:
-    cdef numpy.npy_intp i
-
-    cdef floating* out_ptr = out_data
-    for i from 0 <= i < out_size by out_step:
-        lineRankOrderFilter1D_floating_inplace[floating](
-            out_ptr, out_step, half_length, rank
-        )
-        out_ptr += out_step

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -1,4 +1,4 @@
-from rank_filter cimport lineRankOrderFilter1D_floating_inplace, ndindex
+from rank_filter cimport lineRankOrderFilter1D_floating_inplace
 
 cimport cython
 


### PR DESCRIPTION
Does some serious simplification of the looping code using a few tricks with C pointers. Drops the `ndindex` code, `extern` for NumPy's `PyArray_GetPtr`, and merges the Cython wrapper with the looping function. Also cleans up the function signature to be a bit more friendly (no unused variables to enable fused types).