### PR TITLE
Rename `image` to `a`

### DIFF
--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -11,7 +11,7 @@ numpy.import_array()
 
 
 @cython.boundscheck(False)
-def lineRankOrderFilter(numpy.ndarray image not None,
+def lineRankOrderFilter(numpy.ndarray a not None,
                         size_t half_length,
                         double rank,
                         int axis=-1,
@@ -20,7 +20,7 @@ def lineRankOrderFilter(numpy.ndarray image not None,
         Runs a linear rank filter kernel along one dimension of an array.
 
         Args:
-            image(numpy.ndarray):      array to run the rank filter over.
+            a(numpy.ndarray):          array to run the rank filter over.
 
             half_length(size_t):       half the window size for the kernel.
 
@@ -32,41 +32,39 @@ def lineRankOrderFilter(numpy.ndarray image not None,
 
             out(numpy.ndarray):        where to store the results to. Creates a
                                        new array if not specified. If it is the
-                                       same as image, it will run in-place.
+                                       same as a, it will run in-place.
 
         Returns:
             out(numpy.ndarray):        result of running the linear rank filter.
     """
 
-    cdef int image_type_num = numpy.PyArray_TYPE(image)
+    cdef int a_type_num = numpy.PyArray_TYPE(a)
     cdef int out_type_num
 
     cdef numpy.ndarray out_swap
 
-    if -image.ndim <= axis < 0:
-        axis += image.ndim
-    elif not (0 <= axis < image.ndim):
-        raise ValueError("`axis` needs to be within `image.ndim`")
+    if -a.ndim <= axis < 0:
+        axis += a.ndim
+    elif not (0 <= axis < a.ndim):
+        raise ValueError("`axis` needs to be within `a.ndim`")
 
-    if not ((half_length + 1) <= image.shape[axis]):
-        raise ValueError("Window must be no bigger than the image.")
+    if not ((half_length + 1) <= a.shape[axis]):
+        raise ValueError("Window must be no bigger than `a.shape[axis]`.")
 
     if not (0.0 <= rank <= 1.0):
         raise ValueError("The rank must be between 0.0 and 1.0.")
 
     if out is None:
-        out = numpy.PyArray_NewCopy(image, numpy.NPY_CORDER)
-        out_type_num = image_type_num
+        out = numpy.PyArray_NewCopy(a, numpy.NPY_CORDER)
+        out_type_num = a_type_num
     else:
         out_type_num = numpy.PyArray_TYPE(out)
-        if image_type_num != out_type_num:
-            raise TypeError("Both `image` and `out` must have the same type.")
-        if not numpy.PyArray_SAMESHAPE(image, out):
-            raise ValueError(
-                "Both `image` and `out` must have the same shape."
-            )
-        if numpy.PyArray_CopyInto(out, image) == -1:
-            raise RuntimeError("Unable to copy `image` to `out`.")
+        if a_type_num != out_type_num:
+            raise TypeError("Both `a` and `out` must have the same type.")
+        if not numpy.PyArray_SAMESHAPE(a, out):
+            raise ValueError("Both `a` and `out` must have the same shape.")
+        if numpy.PyArray_CopyInto(out, a) == -1:
+            raise RuntimeError("Unable to copy `a` to `out`.")
 
     out_swap = numpy.PyArray_SwapAxes(out, axis, out.ndim - 1)
     out_swap = numpy.PyArray_GETCONTIGUOUS(out_swap)
@@ -85,7 +83,7 @@ def lineRankOrderFilter(numpy.ndarray image not None,
         )
     else:
         raise TypeError(
-            "Only `float32` and `float64` are supported for `image` and `out`."
+            "Only `float32` and `float64` are supported for `a` and `out`."
         )
 
     out_swap = numpy.PyArray_SwapAxes(out_swap, out.ndim - 1, axis)


### PR DESCRIPTION
This works on any array and not just images. As we already broke API, go ahead and rename this array variable to something that is a bit more general.