### PR TITLE
Use size_t indices

### DIFF
--- a/include/rank_filter.hxx
+++ b/include/rank_filter.hxx
@@ -70,15 +70,15 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     // Store all multiset iterators into the deque in sequential order.
     {
         std::deque<T> window_init(half_length_add_1);
-        for (I_diff_t j = half_length_add_1; j > 0;)
+        for (size_t j = half_length_add_1; j > 0;)
         {
             window_init[--j] = *(src_pos++);
         }
-        for (I_diff_t j = 0; j < half_length; j++)
+        for (size_t j = 0; j < half_length; j++)
         {
             window_iters[j] = sorted_window.insert(window_init[j]);
         }
-        for (I_diff_t j = half_length; j < length; j++)
+        for (size_t j = half_length; j < length; j++)
         {
             window_iters[j] = sorted_window.insert(window_init.back());
             window_init.pop_back();
@@ -86,7 +86,7 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     }
 
     // Window position corresponding to this rank.
-    const I_diff_t rank_pos = static_cast<I_diff_t>(boost::math::round(rank * length_sub_1));
+    const size_t rank_pos = static_cast<size_t>(boost::math::round(rank * length_sub_1));
     typename multiset::iterator rank_point = sorted_window.begin();
     std::advance(rank_point, rank_pos);
 
@@ -95,7 +95,7 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     T prev_value;
     T rank_value;
     T next_value;
-    I_diff_t window_reflect_pos = length_sub_1;
+    size_t window_reflect_pos = length_sub_1;
     bool src_not_empty = ( src_pos != src_end );
     while ( src_not_empty || ( window_reflect_pos > 0 ) )
     {

--- a/include/rank_filter.hxx
+++ b/include/rank_filter.hxx
@@ -28,13 +28,10 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
     // Types in use.
     typedef typename std::iterator_traits<I1>::value_type T1;
     typedef typename std::iterator_traits<I2>::value_type T2;
-    typedef typename std::iterator_traits<I1>::difference_type I1_diff_t;
-    typedef typename std::iterator_traits<I2>::difference_type I2_diff_t;
 
     // Establish common types to work with source and destination values.
     BOOST_STATIC_ASSERT((boost::is_same<T1, T2>::value));
     typedef T1 T;
-    typedef typename boost::common_type<I1_diff_t, I2_diff_t>::type I_diff_t;
 
     // Define container types that will be used.
     typedef boost::container::multiset< T,

--- a/src/rank_filter.pyx
+++ b/src/rank_filter.pyx
@@ -48,7 +48,7 @@ def lineRankOrderFilter(numpy.ndarray a not None,
     elif not (0 <= axis < a.ndim):
         raise ValueError("`axis` needs to be within `a.ndim`")
 
-    if not ((half_length + 1) <= a.shape[axis]):
+    if not ((half_length + 1) <= <size_t>(a.shape[axis])):
         raise ValueError("Window must be no bigger than `a.shape[axis]`.")
 
     if not (0.0 <= rank <= 1.0):


### PR DESCRIPTION
Previously the code used difference types for the respective iterators. This made sense when the code still took differences between iterators and used these differences to implement the moving window. However the code has since been rewritten to support forward iterators, and all remaining indices are connected to the window length, which is `size_t`. Hence all indices are switched to `size_t`.