### PR TITLE
Drop Windows 32-bit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,25 +1,13 @@
 environment:
 
   matrix:
-    - TARGET_ARCH: x86
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
     - TARGET_ARCH: x64
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
-    - TARGET_ARCH: x86
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
     - TARGET_ARCH: x64
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
       CONDA_PY: 36


### PR DESCRIPTION
With as many jobs this takes, the fact that the builds each take a bit, and only one build runs at a time, we need to be a bit more economical with which builds we choose to run. In particular, it doesn't make sense to continue supporting Windows 32-bit. We don't use 32-bit.  Also the user base of 32-bit has been dwindling generally (as shown by a conda-forge survey). Removing 32-bit would halve the number of builds. Given all of this, dropping 32-bit seems like the right move and so we do it here.