### PR TITLE
Handle window center outside of `for`-loops

### DIFF
--- a/include/rank_filter.hxx
+++ b/include/rank_filter.hxx
@@ -79,11 +79,15 @@ inline void lineRankOrderFilter1D(const I1& src_begin, const I1& src_end,
         {
             window_iters[j] = sorted_window.insert(window_init[j]);
         }
-        for (size_t j = half_length; j < length; ++j)
+        window_iters[half_length] = sorted_window.insert(
+            window_init[half_length]
+        );
+        for (size_t j = half_length_add_1; j < length; ++j)
         {
-            window_iters[j] = sorted_window.insert(window_init.back());
             window_init.pop_back();
+            window_iters[j] = sorted_window.insert(window_init.back());
         }
+        window_init.pop_back();
     }
 
     // Window position corresponding to this rank.


### PR DESCRIPTION
By moving the window center case out of the `for`-loops, it makes it a little clearer that the left side of the window holds the reflection of the right side and the center is the first point from the source.